### PR TITLE
Added dot-gitattributes to avoid platform issues

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
We should use a git attributes file to indicate that text files should not have random end of line conventions inherited from the source operating system of the contributer, but instead have one, and the usual one on the server with automatic re-encoding.