### PR TITLE
Added a minimal dot-gitignore to shield the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Operating Systems
+.DS_Store
+
+# Editors
+*~
+.idea
+.vscode


### PR DESCRIPTION
When working on local clones, many objects come into existence that only make sense on then local system (like editor / IDE configurations and backup files) or should not be shared as they may expose data of the local system (like the `.DS_Store` files that the MacOS creates).

This git ignore file shields against typical unwanted files and is kept minimal.

We can always add further ignore patterns later, but this should be a better start than relying on the implicit ignore rules of git.