### PR TITLE
Added and documented a meeting minutes place

### DIFF
--- a/meeting-minutes/README.md
+++ b/meeting-minutes/README.md
@@ -1,0 +1,6 @@
+# Meeting Minutes
+
+This is an area where the TC may decide to provide mneeting minutes in a format that is ideally directly rendered for readers and for search to optimize the public interface of the TC.
+
+When using markdown, anyone can directly refer to sections in such minutes to communicate with ease in issues, pull-requests,
+and towards OASIS administration in requests that require a documented will of the TC in minutes more directly.


### PR DESCRIPTION
This change-set proposes a place and way to store and thus provide the TC meeting minutes
that optimizes re-use and transparency.

Please refer to the initial text of the /meeting-minutes/README.md file for the rationale and options.
